### PR TITLE
Use extends instead of manual merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,11 @@ Licensed under the **MIT** license, see LICENSE for more information.
 
 Available via [npm](https://www.npmjs.com):
 
-### ES6
-
 ```shell
 npm install --save-dev eslint-config-hyperoslo eslint-config-airbnb babel-eslint
 ```
 
-Tweak `.eslintrc`:
+### ES6
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Licensed under the **MIT** license, see LICENSE for more information.
 
 Available via [npm](https://www.npmjs.com):
 
+### ES6
+
 ```shell
-npm install --save-dev eslint-config-hyperoslo babel-eslint
+npm install --save-dev eslint-config-hyperoslo eslint-config-airbnb babel-eslint
 ```
 
 Tweak `.eslintrc`:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ npm install --save-dev eslint-config-hyperoslo eslint-config-airbnb babel-eslint
 
 ### ES6
 
+Tweak `.eslintrc`:
+
 ```json
 {
   "extends": "hyperoslo"

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const merge = require('merge');
-const airbnb = require('eslint-config-airbnb/base');
-
-const hyperoslo = {
+module.exports = {
+  extends: [
+    'eslint-config-airbnb/base',
+  ],
   rules: {
     // Allow anonymous functions
     'func-names': [0],
@@ -10,5 +10,3 @@ const hyperoslo = {
     'object-curly-spacing': [2, 'always'],
   },
 };
-
-module.exports = merge.recursive(airbnb, hyperoslo);

--- a/package.json
+++ b/package.json
@@ -9,12 +9,9 @@
   "repository": "hyperoslo/eslint-config",
   "author": "Tim Kurvers <tim@moonsphere.net>",
   "license": "MIT",
-  "dependencies": {
-    "eslint-config-airbnb": "0.0.8",
-    "merge": "^1.2.0"
-  },
   "devDependencies": {
     "babel-eslint": "^4.1.1",
-    "eslint": "^1.3.1"
+    "eslint": "^1.3.1",
+    "eslint-config-airbnb": "^0.1.0"
   }
 }


### PR DESCRIPTION
This requires package users to install `eslint-config-airbnb` as a dependency, which is unfortunate, but less hacky.
