### PR TITLE
ES5 legacy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ Licensed under the **MIT** license, see LICENSE for more information.
 Available via [npm](https://www.npmjs.com):
 
 ```shell
-npm install --save-dev eslint-config-hyperoslo eslint-config-airbnb babel-eslint
+npm install --save-dev eslint-config-hyperoslo eslint-config-airbnb
 ```
 
 ### ES6
+
+Additional dependencies to install:
+
+```shell
+npm install --save-dev babel-eslint
+```
 
 Tweak `.eslintrc`:
 
@@ -24,28 +30,22 @@ Tweak `.eslintrc`:
 }
 ```
 
-### ES5
+### ES5 (legacy)
 
-You only need the eslint-config-arbnb.
-
-```shell
-npm install --save-dev eslint-config-airbnb
-```
-
-Tweak `.eslintrc` to refer to the ES5 version of Airbnb config:
+Tweak `.eslintrc`:
 
 ```json
 {
-  "extends": "airbnb/legacy",
+  "extends": "hyperoslo/legacy",
 }
 ```
 
 ### React
 
-In addition to the base dependencies above, install the following:
+Additional dependencies to install:
 
 ```shell
-npm install --save-dev eslint-plugin-react
+npm install --save-dev babel-eslint eslint-plugin-react
 ```
 
 Tweak `.eslintrc`:

--- a/base.js
+++ b/base.js
@@ -1,0 +1,9 @@
+module.exports = {
+  rules: {
+    // Allow anonymous functions
+    'func-names': [0],
+
+    // Enforce curly spacing in object literals and destructuring
+    'object-curly-spacing': [2, 'always'],
+  },
+};

--- a/fixtures/es6/.eslintrc
+++ b/fixtures/es6/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": "hyperoslo"
+}

--- a/fixtures/es6/index.js
+++ b/fixtures/es6/index.js
@@ -1,0 +1,4 @@
+export default function() {
+  const config = { enabled: true };
+  return config;
+}

--- a/fixtures/legacy/.eslintrc
+++ b/fixtures/legacy/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": "hyperoslo/legacy"
+}

--- a/fixtures/legacy/index.js
+++ b/fixtures/legacy/index.js
@@ -1,0 +1,4 @@
+module.exports = function() {
+  var config = { enabled: true };
+  return config;
+};

--- a/fixtures/react/.eslintrc
+++ b/fixtures/react/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": "hyperoslo/react"
+}

--- a/fixtures/react/index.jsx
+++ b/fixtures/react/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+class Configuration extends React.Component {
+
+  constructor() {
+    this.state = { enabled: true };
+  }
+
+  render() {
+    return (
+      <config>
+        { this.state.enabled }
+      </config>
+    );
+  }
+
+}
+
+export default Configuration;

--- a/legacy.js
+++ b/legacy.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    'eslint-config-airbnb/base',
+    'eslint-config-airbnb/legacy',
     'eslint-config-hyperoslo/base',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hyper's ESLint config",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint *.js; exit 0"
+    "lint": "eslint **/*.{js,jsx}; exit 0"
   },
   "repository": "hyperoslo/eslint-config",
   "author": "Tim Kurvers <tim@moonsphere.net>",
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-eslint": "^4.1.1",
     "eslint": "^1.3.1",
-    "eslint-config-airbnb": "^0.1.0"
+    "eslint-config-airbnb": "^0.1.0",
+    "eslint-plugin-react": "^3.5.1"
   }
 }


### PR DESCRIPTION
Fixes #7.
- ES5+ rules in `base.js`.
- ES6+ rules in `index.js`.
- React-specific rules in `react.js`.

Have also added some fixtures that allow us to quickly test rules in an editor and/or using `npm run lint`.
