### PR TITLE
Enforce indentation of switch/case statements

### DIFF
--- a/base.js
+++ b/base.js
@@ -3,6 +3,10 @@ module.exports = {
     // Allow anonymous functions
     'func-names': [0],
 
+    // Enforce indentation of switch/case statements
+    // See: https://github.com/airbnb/javascript/issues/470#issuecomment-145066890
+    'indent': [2, 2, { SwitchCase: 1 }],
+
     // Enforce curly spacing in object literals and destructuring
     'object-curly-spacing': [2, 'always'],
   },

--- a/fixtures/es6/index.js
+++ b/fixtures/es6/index.js
@@ -1,4 +1,12 @@
-export default function() {
+export default function(flag) {
   const config = { enabled: true };
+
+  switch (flag) {
+    case 0:
+      config.enabled = false;
+      break;
+    default:
+  }
+
   return config;
 }

--- a/fixtures/legacy/index.js
+++ b/fixtures/legacy/index.js
@@ -1,4 +1,12 @@
-module.exports = function() {
+module.exports = function(flag) {
   var config = { enabled: true };
+
+  switch (flag) {
+    case 0:
+      config.enabled = false;
+      break;
+    default:
+  }
+
   return config;
 };

--- a/fixtures/react/index.jsx
+++ b/fixtures/react/index.jsx
@@ -2,8 +2,15 @@ import React from 'react';
 
 class Configuration extends React.Component {
 
-  constructor() {
+  constructor(props) {
     this.state = { enabled: true };
+
+    switch (props.flag) {
+      case 0:
+        this.state.enabled = false;
+        break;
+      default:
+    }
   }
 
   render() {


### PR DESCRIPTION
Enforce:

``` javascript
switch (flag) {
  case 0:
    config.enabled = false;
    break;
  default:
}
```

Over:

``` javascript
switch (flag) {
case 0:
  config.enabled = false;
  break;
default:
}
```
