### PR TITLE
Enforce babel-eslint parser for ES6+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: 'babel-eslint',
   extends: [
     'eslint-config-airbnb/base',
     'eslint-config-hyperoslo/base',


### PR DESCRIPTION
Airbnb has [removed `babel-eslint` in 1.0.0](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb#100) as the default parser.

This PR adds it explicitly to ours for ES6+ linting.
